### PR TITLE
refs #299: Implementata pagina linee guida come da mockup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -164,7 +164,8 @@
     "drupal/block_titlelink": "1.x-dev",
     "drupal/block_class": "1.x-dev",
     "abraham/twitteroauth": "^0.7.4",
-    "drupal/share_everywhere": "^1.1"
+    "drupal/share_everywhere": "^1.1",
+    "drupal/better_exposed_filters": "^3.0@alpha"
   },
   "require-dev": {
     "phing/phing": "2.12.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f15d258a961bf9076b0740fb4bb1124",
+    "content-hash": "fe4740a3e7d8d8b58a12e8c6931b87fa",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -2169,6 +2169,65 @@
                 "issues": "https://www.drupal.org/project/issues/backup_migrate"
             },
             "time": "2018-02-21T12:04:27+00:00"
+        },
+        {
+            "name": "drupal/better_exposed_filters",
+            "version": "3.0.0-alpha3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/better_exposed_filters",
+                "reference": "8.x-3.0-alpha3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/better_exposed_filters-8.x-3.0-alpha3.zip",
+                "reference": "8.x-3.0-alpha3",
+                "shasum": "0268a42ea5a4ab170c8f4aefecd26b6f3c7448d2"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.0-alpha3",
+                    "datestamp": "1501274342",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "jkopel",
+                    "homepage": "https://www.drupal.org/user/66207"
+                },
+                {
+                    "name": "mikeker",
+                    "homepage": "https://www.drupal.org/user/192273"
+                },
+                {
+                    "name": "mortona2k",
+                    "homepage": "https://www.drupal.org/user/1029484"
+                },
+                {
+                    "name": "rlhawk",
+                    "homepage": "https://www.drupal.org/user/352283"
+                }
+            ],
+            "description": "Provides advanced options (such as links, checkboxes, or jQueryUI widgets) for exposed Views elements.",
+            "homepage": "https://www.drupal.org/project/better_exposed_filters",
+            "support": {
+                "source": "http://cgit.drupalcode.org/better_exposed_filters"
+            }
         },
         {
             "name": "drupal/block_class",
@@ -5548,6 +5607,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Ajax support / Use behaviors for 2.x": "https://www.drupal.org/files/issues/2018-03-21/2493183-ajax-support-91.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -11701,6 +11763,7 @@
         "drupal/seckit": 15,
         "drupal/block_titlelink": 20,
         "drupal/block_class": 20,
+        "drupal/better_exposed_filters": 15,
         "jcalderonzumba/gastonjs": 20,
         "drupal/migrate_devel": 20
     },

--- a/config/agid/sync/block.block.exposedform_guide_lines.yml
+++ b/config/agid/sync/block.block.exposedform_guide_lines.yml
@@ -1,0 +1,33 @@
+uuid: a7a45770-fe2c-4185-a9d3-f270771fc81c
+langcode: it
+status: true
+dependencies:
+  config:
+    - views.view.linee_guida
+  module:
+    - block_class
+    - system
+    - views
+  theme:
+    - agid
+third_party_settings:
+  block_class:
+    classes: guide-lines-form
+id: exposedform_guide_lines
+theme: agid
+region: sidebar_left
+weight: -16
+provider: null
+plugin: 'views_exposed_filter_block:linee_guida-guide_lines'
+settings:
+  id: 'views_exposed_filter_block:linee_guida-guide_lines'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+visibility:
+  request_path:
+    id: request_path
+    pages: "/linee-guida\r\n/linee-guida*"
+    negate: false
+    context_mapping: {  }

--- a/config/agid/sync/block.block.pagetitle.yml
+++ b/config/agid/sync/block.block.pagetitle.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   module:
     - block_class
-    - ctools
     - system
   theme:
     - agid
@@ -25,13 +24,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
+    pages: "<front>\r\n/piattaforme/spid/identity-provider-accreditati/*"
     negate: true
     context_mapping: {  }
-  'entity_bundle:node':
-    id: 'entity_bundle:node'
-    bundles:
-      acc_subj: acc_subj
-    negate: true
-    context_mapping:
-      node: '@node.node_route_context:node'

--- a/config/agid/sync/core.entity_form_display.paragraph.more_info.default.yml
+++ b/config/agid/sync/core.entity_form_display.paragraph.more_info.default.yml
@@ -32,6 +32,12 @@ content:
         maxlength_js_truncate_html: false
     type: string_textarea
     region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
 hidden:
   created: true
   status: true

--- a/config/agid/sync/core.extension.yml
+++ b/config/agid/sync/core.extension.yml
@@ -16,6 +16,7 @@ module:
   automated_cron: 0
   backup_migrate: 0
   ban: 0
+  better_exposed_filters: 0
   block: 0
   block_class: 0
   block_content: 0

--- a/config/agid/sync/views.view.linee_guida.yml
+++ b/config/agid/sync/views.view.linee_guida.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.storage.file.field_arguments
-    - field.storage.file.field_date
     - field.storage.file.field_title
     - field.storage.file.field_type
     - taxonomy.vocabulary.arguments
@@ -12,7 +11,7 @@ dependencies:
   content:
     - 'taxonomy_term:file_type:004fc6ab-d5f8-45ea-9483-4e7d2a7a39ef'
   module:
-    - datetime
+    - better_exposed_filters
     - file
     - file_entity
     - node
@@ -49,33 +48,53 @@ display:
           query_comment: ''
           query_tags: {  }
       exposed_form:
-        type: basic
+        type: bef
         options:
           submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
+          reset_button: true
+          reset_button_label: 'Tutti gli argomenti'
           exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
+          expose_sort_order: false
           sort_asc_label: Asc
           sort_desc_label: Desc
+          input_required: false
+          text_input_required: 'Seleziona qualsiasi filtro e clicca su Applica per visualizzare i risultati'
+          bef:
+            general:
+              allow_secondary: false
+              secondary_label: 'Opzioni avanzate'
+              autosubmit: false
+              autosubmit_hide: false
+            field_arguments_target_id_1:
+              bef_format: bef
+              more_options:
+                bef_select_all_none: false
+                bef_collapsible: false
+                is_secondary: false
+                rewrite:
+                  filter_rewrite_values: ''
+          text_input_required_format: filtered_text
       pager:
         type: none
         options:
           offset: 0
       style:
-        type: default
+        type: html_list
         options:
           grouping:
             -
               field: field_arguments
               rendered: true
               rendered_strip: false
-          row_class: ''
+          row_class: guide-line-item
           default_row_class: true
+          type: ul
+          wrapper_class: 'agid-guide-lines__group Prose u-layout-prose'
+          class: agid-guide-lines__list
       row:
         type: fields
         options:
-          default_field_elements: true
+          default_field_elements: false
           inline:
             field_arguments: field_arguments
             field_type: field_type
@@ -218,10 +237,10 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
-            text: ''
+            text: '<p>{{ field_title }}</p>'
             make_link: false
             path: ''
             absolute: false
@@ -265,10 +284,10 @@ display:
             fieldsets:
               - more
               - admin_label
-            custom_label: 1
-            label: 'Titolo documento'
-            element_label_colon: 1
-            exclude: 0
+            custom_label: 0
+            label: ''
+            element_label_colon: 0
+            exclude: 1
             element_type_enable: 0
             element_type: ''
             element_class_enable: 0
@@ -338,7 +357,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: ' ({{ filesize }})'
+            text: '{{ field_title }} ({{ filesize }})'
             make_link: false
             path: ''
             absolute: false
@@ -368,9 +387,9 @@ display:
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
+          element_wrapper_type: span
+          element_wrapper_class: guide-line-item__file
+          element_default_classes: false
           empty: ''
           hide_empty: false
           empty_zero: false
@@ -391,6 +410,73 @@ display:
           entity_type: file
           entity_field: filesize
           plugin_id: field
+        changed:
+          id: changed
+          table: file_managed
+          field: changed
+          relationship: field_repository_files
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<strong>Data:</strong> {{ changed }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: div
+          element_wrapper_class: guide-line-item__date
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: custom
+            custom_date_format: d/m/Y
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: file
+          entity_field: changed
+          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -402,7 +488,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: '<span class="u-text-r-xxs">appare in {{ title }}</span>'
+            text: '<strong>Pagina del sito:</strong> {{ title }}'
             make_link: false
             path: ''
             absolute: false
@@ -432,8 +518,8 @@ display:
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: div
+          element_wrapper_class: guide-line-item__page
           element_default_classes: false
           empty: ''
           hide_empty: false
@@ -455,70 +541,6 @@ display:
           field_api_classes: false
           entity_type: node
           entity_field: title
-          plugin_id: field
-        field_date:
-          id: field_date
-          table: file__field_date
-          field: field_date
-          relationship: field_repository_files
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: true
-            text: '<b class="u-color-50">Data:</b> {{ field_date }}'
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: 'Nessuna data specificata.'
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: false
-          click_sort_column: value
-          type: datetime_custom
-          settings:
-            timezone_override: ''
-            date_format: d/m/Y
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
           plugin_id: field
       filters:
         status:
@@ -649,22 +671,69 @@ display:
           hierarchy: false
           error_message: true
           plugin_id: taxonomy_index_tid
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          relationship: none
+        field_arguments_target_id_1:
+          id: field_arguments_target_id_1
+          table: file__field_arguments
+          field: field_arguments_target_id
+          relationship: field_repository_files
           group_type: group
           admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_arguments_target_id_1_op
+            label: FILTRI
+            description: ''
+            use_operator: false
+            operator: field_arguments_target_id_1_op
+            identifier: arguments
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              author: '0'
+              publisher: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: arguments
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      sorts:
+        changed:
+          id: changed
+          table: file_managed
+          field: changed
+          relationship: field_repository_files
+          group_type: group
+          admin_label: ''
+          order: DESC
           exposed: false
           expose:
             label: ''
           granularity: second
+          entity_type: file
+          entity_field: changed
+          plugin_id: date
       title: 'Linee guida'
       header: {  }
       footer: {  }
@@ -690,37 +759,39 @@ display:
           plugin_id: standard
       arguments: {  }
       display_extenders: {  }
+      css_class: agid-guide-lines
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.file.field_arguments'
-        - 'config:field.storage.file.field_date'
         - 'config:field.storage.file.field_title'
         - 'config:field.storage.file.field_type'
-  page_1:
+  guide_lines:
     display_plugin: page
-    id: page_1
+    id: guide_lines
     display_title: Page
     position: 1
     display_options:
       display_extenders: {  }
       path: linee-guida
+      exposed_block: true
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.file.field_arguments'
-        - 'config:field.storage.file.field_date'
         - 'config:field.storage.file.field_title'
         - 'config:field.storage.file.field_type'

--- a/web/themes/custom/agid/agid.theme
+++ b/web/themes/custom/agid/agid.theme
@@ -92,7 +92,5 @@ function agid_preprocess_page(&$variables) {
  * Implements template_preprocess_html().
  */
 function agid_preprocess_html(&$variables) {
-
   $variables['icon_path'] = '/' . drupal_get_path('theme','agid') . '/icons';
-
 }

--- a/web/themes/custom/agid/css/agid.css
+++ b/web/themes/custom/agid/css/agid.css
@@ -1695,23 +1695,40 @@ div.Prose,
 
 .Prose ul li,
 .Prose ol li {
+  position: relative;
+  padding-left: 2.3rem;
   line-height: 1.55 !important;
 }
 
 .Prose li::before {
+  position: absolute;
+  width: 1rem;
+  height: 2rem;
+  top: 0.3rem;
+  left: -0.2rem;
+  font-size: 2.4rem;
+  line-height: 1;
+  color: #0059B3;
   content: "\25CF";
-  color: #0059b3;
-  font-size: 2rem;
-  margin-right: 1.2rem;
 }
 
 .Prose li li::before {
   content: "\25CB";
+  top: 0rem;
 }
 
 .Prose .Abstract p {
   font-size: 1.1em !important;
   color: #0059b3 !important;
+}
+
+@media screen and (min-width: 768px) {
+  .Prose li::before {
+    top: 0.5rem;
+  }
+  .Prose li li::before {
+    top: 0.1rem;
+  }
 }
 
 div.documentation div.file {
@@ -1778,5 +1795,228 @@ div.documentation h3 {
 @media screen and (min-width: 640px) {
   .acc-subj-info__text-value {
     min-height: 60px;
+  }
+}
+
+/**
+ * @file
+ * Style customization for the guide lines page.
+ */
+/*Fix megamenu style (we do not have a dropdown)*/
+a[href*="linee-guida"] {
+  padding-right: 1rem !important;
+}
+
+a[href*="linee-guida"]::after {
+  display: none;
+}
+
+.agid-guide-lines__group H3 {
+  padding: 2rem 1rem 0.75rem;
+  border-bottom: 1px solid #D0E2F6;
+  text-transform: capitalize;
+  font-weight: 600 !important;
+}
+
+.guide-line-item {
+  margin-bottom: 0.3rem;
+}
+
+.guide-line-item A {
+  color: #00264C !important;
+}
+
+.guide-line-item STRONG {
+  font-weight: 600;
+  color: #0059B3;
+}
+
+.guide-line-item__file {
+  display: inline-block;
+  margin: 0 0 0.75rem 0;
+}
+
+.guide-line-item__date,
+.guide-line-item__page,
+.guide-line-item__page A {
+  font-size: 1.5rem;
+  margin: 0.75rem 0;
+}
+
+.guide-lines-form {
+  margin-top: 0 !important;
+  padding: 0;
+  background-color: transparent;
+}
+
+.guide-lines-form .form-submit {
+  margin-right: 16px;
+}
+
+.guide-lines-form .Form {
+  position: relative;
+  padding-top: 65px !important;
+}
+
+.guide-lines-form .Form-legend {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 50px;
+  width: auto;
+  display: block;
+  line-height: 50px;
+  padding: 0 16px;
+  color: #FFF;
+  background-color: #0059B3;
+}
+
+.guide-lines-form .Form-label--block {
+  position: relative;
+  padding: 1.75rem 1rem 1.75rem 46px !important;
+  min-height: auto;
+  border-width: 0;
+  line-height: 22px;
+  cursor: pointer;
+  text-transform: capitalize;
+}
+
+.guide-lines-form .Form-label--block .Form-fieldIcon {
+  position: absolute;
+  left: 5px;
+  top: 1.2rem;
+}
+
+/*Fake reset button*/
+.guide-lines-form__reset {
+  display: none;
+  width: 100%;
+  line-height: 22px;
+  text-align: left;
+  position: relative;
+  cursor: pointer;
+  text-transform: none;
+  color: #00264D;
+  padding-left: 46px;
+  padding-right: 1rem;
+  margin: 2rem 0 4rem;
+}
+
+.js .guide-lines-form__reset {
+  display: block;
+}
+
+.guide-lines-form__reset .Icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translate(0, -50%);
+}
+
+/* Hyde the real reset button, we add a fake button, working with JS */
+.js .guide-lines-form #edit-reset {
+  display: none;
+}
+
+.agid-guide-lines__mobile-toggler {
+  display: none;
+  position: relative;
+  width: 100%;
+  height: 50px;
+  padding: 0 1rem;
+  margin-bottom: 3rem;
+  line-height: 50px;
+  color: #FFF;
+  background-color: #0059B3;
+  cursor: pointer;
+}
+
+.agid-guide-lines__mobile-toggler .Icon {
+  position: absolute;
+  right: 2rem;
+  top: 50%;
+  transform: translate(0, -50%);
+}
+
+.agid-guide-lines__mobile-toggler.is-open .Icon::before {
+  content: "\25b2" !important;
+}
+
+@media screen and (max-width: 991px) {
+  /*Style exposed filters on mobile*/
+  .js .agid-guide-lines__filters-wrapper {
+    display: none;
+    position: absolute;
+    z-index: 10;
+    top: -3rem;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: auto;
+    height: auto;
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8cOfOTAAIbwMzvgT++gAAAABJRU5ErkJggg==);
+  }
+  .js .guide-lines-form {
+    position: absolute;
+    z-index: 11;
+    top: 0;
+    right: 0;
+    left: auto;
+    max-width: 300px;
+    background: #FFF;
+    border-width: 0;
+  }
+  .js .guide-lines-form .Form {
+    padding-top: 1.5rem !important;
+  }
+  .js .guide-lines-form .Form-legend {
+    display: none;
+  }
+  .js .guide-lines-form .Form-label--block::before {
+    content: '';
+    position: absolute;
+    top: 0rem;
+    right: 1.25rem;
+    left: 1.25rem;
+    width: auto;
+    height: 1px;
+    background: #D0E2F6;
+  }
+  .js .agid-guide-lines__mobile-toggler {
+    display: block;
+  }
+  /* Set styles when the filters are open */
+  /*Color the HTML element to simulate an overlay layer*/
+  .is-open-agid-guide-lines-filters {
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8cOfOTAAIbwMzvgT++gAAAABJRU5ErkJggg==);
+    /*Manage footer overlay*/
+  }
+  .is-open-agid-guide-lines-filters .agid-guide-lines__filters-wrapper {
+    display: block;
+  }
+  .is-open-agid-guide-lines-filters MAIN {
+    background-color: #FFF;
+  }
+  .is-open-agid-guide-lines-filters .u-background-95 {
+    position: relative;
+  }
+  .is-open-agid-guide-lines-filters .u-background-95:before {
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    content: ' ';
+    background-color: #E0DCDC;
+    /*+opacity: 60%;*/
+    -filter: alpha(opacity=60);
+    -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=60);
+    -moz-opacity: 0.6;
+    opacity: 0.6;
+    z-index: 9;
   }
 }

--- a/web/themes/custom/agid/js/agid.js
+++ b/web/themes/custom/agid/js/agid.js
@@ -1,5 +1,6 @@
 /**
  * @file
+ * @file
  * A JavaScript file for the theme.
  */
 
@@ -67,7 +68,8 @@
 
     jQuery('.Megamenu-item').each(
       function (index, elem) {
-        if (jQuery(elem).find('a').length == 1)
+        // @TODO find a better solution than hardcode the "linee-guida" path.
+        if (jQuery(elem).find('a').length == 1 && window.location.pathname.indexOf('linee-guida') < 0)
           return;
         var link_orig = jQuery(elem).find('a').first();
         var link_copy = jQuery('<a/>');
@@ -191,5 +193,30 @@
       }
     }
   };
+
+  // Javascript specific for the Guide Lines page.
+  Drupal.behaviors.guideLines = {
+    attach: function (context, settings) {
+      // If we are in the guide-lines page we have the exposed filters.
+      if ($('#guideLinesFiltersMobileToggler').length) {
+
+        // Manage click on the filters toggler.
+        $('#guideLinesFiltersMobileToggler').click(function () {
+          $(this).toggleClass('is-open');
+          $('html').toggleClass('is-open-agid-guide-lines-filters');
+        })
+
+        // Manage behavior and click on the fake reset button.
+        if(window.location.search) {
+          $('#guideLinesFormReset').find('.Icon').removeClass('Icon-radio-button-checked').addClass('Icon-radio-button');
+        }
+        $('#guideLinesFormReset').click(function () {
+          $('#views-exposed-form-linee-guida-guide-lines').find('[id*="edit-reset"]').trigger('click');
+        })
+
+        // Enable the megamenu voice.
+      }
+    }
+  }
 
 })(jQuery, Drupal, this, this.document);

--- a/web/themes/custom/agid/scss/agid.scss
+++ b/web/themes/custom/agid/scss/agid.scss
@@ -45,3 +45,4 @@
 
 // Styles relative to single components.
 @import 'components/acc_subj';
+@import 'components/guide_lines';

--- a/web/themes/custom/agid/scss/components/_guide_lines.scss
+++ b/web/themes/custom/agid/scss/components/_guide_lines.scss
@@ -1,0 +1,235 @@
+/**
+ * @file
+ * Style customization for the guide lines page.
+ */
+/*Fix megamenu style (we do not have a dropdown)*/
+a[href*="linee-guida"] {
+  padding-right: 1rem !important;
+
+  &::after {
+    display: none;
+  }
+}
+
+.agid-guide-lines__group {
+  H3 {
+    padding: 2rem 1rem 0.75rem;
+    border-bottom: 1px solid #D0E2F6;
+    text-transform: capitalize;
+    font-weight: 600 !important;
+  }
+}
+
+.guide-line-item {
+  margin-bottom: 0.3rem;
+
+  A {
+    color: #00264C !important;
+  }
+
+  STRONG {
+    font-weight: 600;
+    color: #0059B3;
+  }
+}
+
+.guide-line-item__file {
+  display: inline-block;
+  margin: 0 0 0.75rem 0;
+}
+
+.guide-line-item__date,
+.guide-line-item__page,
+.guide-line-item__page A {
+  font-size: 1.5rem;
+  margin: 0.75rem 0;
+}
+
+// Exposed form in the sidebar
+.guide-lines-form {
+  margin-top: 0 !important;
+  padding: 0;
+  background-color: transparent;
+
+  .form-submit {
+    margin-right: 16px;
+  }
+
+  .Form {
+    position: relative;
+    padding-top: 65px !important;
+  }
+
+  .Form-legend {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 50px;
+    width: auto;
+    display: block;
+    line-height: 50px;
+    padding: 0 16px;
+    color: #FFF;
+    background-color: #0059B3;
+  }
+
+  .Form-label--block {
+    position: relative;
+    padding: 1.75rem 1rem 1.75rem 46px !important;
+    min-height: auto;
+    border-width: 0;
+    line-height: 22px;
+    cursor: pointer;
+    text-transform: capitalize;
+
+    .Form-fieldIcon {
+      position: absolute;
+      left: 5px;
+      top: 1.2rem;
+    }
+  }
+}
+
+/*Fake reset button*/
+.guide-lines-form__reset {
+  display: none;
+  width: 100%;
+  line-height: 22px;
+  text-align: left;
+  position: relative;
+  cursor: pointer;
+  text-transform: none;
+  color: #00264D;
+  padding-left: 46px;
+  padding-right: 1rem;
+  margin: 2rem 0 4rem;
+}
+
+.js .guide-lines-form__reset {
+  display: block;
+}
+
+.guide-lines-form__reset .Icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translate(0, -50%);
+}
+
+/* Hyde the real reset button, we add a fake button, working with JS */
+.js .guide-lines-form #edit-reset {
+  display: none;
+}
+
+.agid-guide-lines__mobile-toggler {
+  display: none;
+  position: relative;
+  width: 100%;
+  height: 50px;
+  padding: 0 1rem;
+  margin-bottom: 3rem;
+  line-height: 50px;
+  color: #FFF;
+  background-color: #0059B3;
+  cursor: pointer;
+}
+
+.agid-guide-lines__mobile-toggler .Icon {
+  position: absolute;
+  right: 2rem;
+  top: 50%;
+  transform: translate(0, -50%);
+}
+
+.agid-guide-lines__mobile-toggler.is-open .Icon::before {
+  content: "\25b2" !important;
+}
+
+@media screen and (max-width: 991px) {
+  /*Style exposed filters on mobile*/
+  .js .agid-guide-lines__filters-wrapper {
+    display: none;
+    position: absolute;
+    z-index: 10;
+    top: -3rem;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: auto;
+    height: auto;
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8cOfOTAAIbwMzvgT++gAAAABJRU5ErkJggg==);
+  }
+
+  .js .guide-lines-form {
+    position: absolute;
+    z-index: 11;
+    top: 0;
+    right: 0;
+    left: auto;
+    max-width: 300px;
+    background: #FFF;
+    border-width: 0;
+
+    .Form {
+      padding-top: 1.5rem !important;
+    }
+
+    .Form-legend {
+      display: none;
+    }
+
+    .Form-label--block::before {
+      content: '';
+      position: absolute;
+      top: 0rem;
+      right: 1.25rem;
+      left: 1.25rem;
+      width: auto;
+      height: 1px;
+      background: #D0E2F6;
+    }
+  }
+
+  .js .agid-guide-lines__mobile-toggler {
+    display: block;
+  }
+
+  /* Set styles when the filters are open */
+  /*Color the HTML element to simulate an overlay layer*/
+  .is-open-agid-guide-lines-filters {
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8cOfOTAAIbwMzvgT++gAAAABJRU5ErkJggg==);
+
+    .agid-guide-lines__filters-wrapper {
+      display: block;
+    }
+
+    MAIN {
+      background-color: #FFF;
+    }
+
+    /*Manage footer overlay*/
+    .u-background-95 {
+      position: relative;
+    }
+
+    .u-background-95:before {
+      display: block;
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      content: ' ';
+      background-color: #E0DCDC;
+      /*+opacity: 60%;*/
+      -filter: alpha(opacity=60);
+      -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=60);
+      -moz-opacity: 0.6;
+      opacity: 0.6;
+      z-index: 9;
+    }
+  }
+}

--- a/web/themes/custom/agid/scss/theme/_typography.scss
+++ b/web/themes/custom/agid/scss/theme/_typography.scss
@@ -30,21 +30,29 @@ div.Prose,
     }
 
     li {
+      position: relative;
+      padding-left: 2.3rem;
       line-height: 1.55 !important;
     }
   }
 
   li {
     &::before {
+      position: absolute;
+      width: 1rem;
+      height: 2rem;
+      top: 0.3rem;
+      left: -0.2rem;
+      font-size: 2.4rem;
+      line-height: 1;
+      color: #0059B3;
       content: "\25CF";
-      color: $light-blue;
-      font-size: 2rem;
-      margin-right: 1.2rem;
     }
 
     li {
       &::before {
         content: "\25CB";
+        top: 0rem;
       }
     }
   }
@@ -55,3 +63,18 @@ div.Prose,
   }
 }
 
+@media screen and (min-width: 768px) {
+  .Prose {
+    li {
+      &::before {
+        top: 0.5rem;
+      }
+
+      li {
+        &::before {
+          top: 0.1rem;
+        }
+      }
+    }
+  }
+}

--- a/web/themes/custom/agid/templates/form/views-exposed-form--linee-guida--guide-lines.html.twig
+++ b/web/themes/custom/agid/templates/form/views-exposed-form--linee-guida--guide-lines.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Theme override of a views exposed form.
+ *
+ * Available variables:
+ * - form: A render element representing the form.
+ *
+ * @see template_preprocess_views_exposed_form()
+ */
+#}
+{% if q is not empty %}
+  {#
+    This ensures that, if clean URLs are off, the 'q' is added first,
+    as a hidden form element, so that it shows up first in the POST URL.
+  #}
+{{ q }}
+{% endif %}
+{# A fake link button you can click with JS enabled to reset all filters #}
+<a id="guideLinesFormReset" class="guide-lines-form__reset" role="presentation">
+  <span class="Icon Icon-radio-button-checked"></span> {{ 'Tutti gli argomenti'|t }}
+</a>
+{{ form }}

--- a/web/themes/custom/agid/templates/layout/page--linee-guida.html.twig
+++ b/web/themes/custom/agid/templates/layout/page--linee-guida.html.twig
@@ -1,0 +1,86 @@
+{% extends "page.html.twig" %}
+{#
+/**
+ * @file
+ * Theme override to display the "Linee guida" page.
+ */
+#}
+{% block page_body %}
+
+  <div class="u-layout-wide u-layoutCenter u-layout-r-withGutter">
+    <div class="Grid Grid--withGutter">
+
+      <div class="Grid-cell u-sizeFull u-md-size3of12 u-lg-size3of12"></div>
+      <div class="Grid-cell u-sizeFull u-md-size9of12 u-lg-size9of12">
+
+        {# Breadcrumb #}
+        {% if page.breadcrumb %}
+          {{ page.breadcrumb }}
+        {% endif %}
+
+      </div>
+    </div>
+  </div>
+
+  {# Help #}
+  {% if page.help|render|striptags|trim %}
+    {{ page.help }}
+  {% endif %}
+
+  {# Hero #}
+  {% if page.hero %}
+    {{ page.hero }}
+  {% endif %}
+
+  <a id="guideLinesFiltersMobileToggler" class="agid-guide-lines__mobile-toggler">{{ 'FILTRI'|t }}<span class="u-text-r-l Icon Icon-drop-up"></span></a>
+
+  {# Page content region #}
+  <div class="u-padding-r-bottom u-posRelative">
+    <div class="u-layout-wide u-layoutCenter u-layout-r-withGutter agid-guide-lines__container">
+      <div class="Grid Grid--withGutter">
+
+        {# Sidebar left #}
+        <div class="Grid-cell u-sizeFull u-md-size3of12 u-lg-size3of12 agid-guide-lines__filters-wrapper">
+          {{ page.sidebar_left }}
+        </div>
+
+        {# Content #}
+        <div class="Grid-cell u-sizeFull u-md-size6of12 u-lg-size6of12">
+          {{ page.content }}
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  {# Postscript first #}
+  {% if page.postscript_first %}
+    {{ page.postscript_first }}
+  {% endif %}
+
+  {# Postscript second #}
+  {% if page.postscript_second %}
+    {{ page.postscript_second }}
+  {% endif %}
+
+  {# Postscript third #}
+  {% if page.postscript_third %}
+    {{ page.postscript_third }}
+  {% endif %}
+
+  {# Postscript fourth #}
+  {% if page.postscript_fourth %}
+    {{ page.postscript_fourth }}
+  {% endif %}
+
+  {# Leads region #}
+  {% if page.leads %}
+    {{ page.leads }}
+  {% endif %}
+
+  {# Pre footer #}
+  {% if page.pre_footer %}
+    {{ page.pre_footer }}
+  {% endif %}
+
+{% endblock %}

--- a/web/themes/custom/agid/templates/layout/page.html.twig
+++ b/web/themes/custom/agid/templates/layout/page.html.twig
@@ -154,40 +154,36 @@
 
     {% block page_body %}
 
-
     <div class="u-layout-wide u-layoutCenter u-layout-r-withGutter">
       <div class="Grid Grid--withGutter">
 
-        {% if page.sidebar_left or force_left_sidebar %}
-          <div class="Grid-cell u-sizeFull u-md-size3of12 u-lg-size3of12">
+      {% if page.sidebar_left or force_left_sidebar %}
+        <div class="Grid-cell u-sizeFull u-md-size3of12 u-lg-size3of12">
 
-          </div>
-          <div class="Grid-cell u-sizeFull u-md-size6of12 u-lg-size6of12">
-        {% else %}
-          <div class="Grid-cell u-sizeFull">
+        </div>
+        <div class="Grid-cell u-sizeFull u-md-size6of12 u-lg-size6of12">
+      {% else %}
+        <div class="Grid-cell u-sizeFull">
+      {% endif %}
+
+        {# Breadcrumb #}
+        {% if page.breadcrumb %}
+          {{ page.breadcrumb }}
         {% endif %}
 
-              {# Breadcrumb #}
-              {% if page.breadcrumb %}
-                  {{ page.breadcrumb }}
-              {% endif %}
-
-
-          </div>
+        </div>
       </div>
     </div>
 
+    {# Help #}
+    {% if page.help|render|striptags|trim %}
+      {{ page.help }}
+    {% endif %}
 
-        {# Help #}
-        {% if page.help|render|striptags|trim %}
-            {{ page.help }}
-        {% endif %}
-
-        {# Hero #}
-        {% if page.hero %}
-            {{ page.hero }}
-        {% endif %}
-
+    {# Hero #}
+    {% if page.hero %}
+      {{ page.hero }}
+    {% endif %}
 
       {# Page content region #}
       <div class="u-padding-r-bottom">
@@ -211,7 +207,7 @@
             <div class="Grid Grid--withGutter">
               {# Sidebar left #}
               <div class="Grid-cell u-sizeFull u-md-size3of12 u-lg-size3of12">
-                  {{ page.sidebar_left }}
+                {{ page.sidebar_left }}
               </div>
               {# Content #}
               <div class="Grid-cell u-sizeFull u-md-size6of12 u-lg-size6of12">


### PR DESCRIPTION
In aggiunta:

- Corretta la stilizzazione globale degli elenchi puntati come [suggerimento di Michela](https://trello.com/c/vqdHbK5L/299-pagina-linee-guida-adattare-laspetto-della-vista-desktop-mobile-come-da-mockup-e-implementare-i-filtri-per-argomento#comment-5aeb17316e57e0e851f628a8)
- Corretta regressione visualizzazione titoli viste introdotta con [lavorazione IDP](https://trello.com/c/vqdHbK5L/299-pagina-linee-guida-adattare-laspetto-della-vista-desktop-mobile-come-da-mockup-e-implementare-i-filtri-per-argomento#comment-5aeb275a48b4be4fe008071a)