### PR TITLE
AGID-218 Modifiche alla home: blocco notizie (324) - Nasconde i campi non traducibili dalla form di traduzione di un nodo.

### DIFF
--- a/config/agid/sync/language.content_settings.block_content.basic.yml
+++ b/config/agid/sync/language.content_settings.block_content.basic.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: block_content.basic
 target_entity_type_id: block_content
 target_bundle: basic

--- a/config/agid/sync/language.content_settings.block_content.basic_custom_block.yml
+++ b/config/agid/sync/language.content_settings.block_content.basic_custom_block.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: block_content.basic_custom_block
 target_entity_type_id: block_content
 target_bundle: basic_custom_block

--- a/config/agid/sync/language.content_settings.entity_subqueue.home_page_highlight_en_.yml
+++ b/config/agid/sync/language.content_settings.entity_subqueue.home_page_highlight_en_.yml
@@ -1,0 +1,11 @@
+uuid: 6e84964d-e482-49d7-8318-4fc95a041345
+langcode: it
+status: true
+dependencies:
+  config:
+    - entityqueue.entity_queue.home_page_highlight_en_
+id: entity_subqueue.home_page_highlight_en_
+target_entity_type_id: entity_subqueue
+target_bundle: home_page_highlight_en_
+default_langcode: site_default
+language_alterable: false

--- a/config/agid/sync/language.content_settings.menu_link_content.menu_link_content.yml
+++ b/config/agid/sync/language.content_settings.menu_link_content.menu_link_content.yml
@@ -8,6 +8,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: menu_link_content.menu_link_content
 target_entity_type_id: menu_link_content
 target_bundle: menu_link_content

--- a/config/agid/sync/language.content_settings.node.acc_subj.yml
+++ b/config/agid/sync/language.content_settings.node.acc_subj.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: node.acc_subj
 target_entity_type_id: node
 target_bundle: acc_subj

--- a/config/agid/sync/language.content_settings.node.event.yml
+++ b/config/agid/sync/language.content_settings.node.event.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: node.event
 target_entity_type_id: node
 target_bundle: event

--- a/config/agid/sync/language.content_settings.node.faq.yml
+++ b/config/agid/sync/language.content_settings.node.faq.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: node.faq
 target_entity_type_id: node
 target_bundle: faq

--- a/config/agid/sync/language.content_settings.node.news.yml
+++ b/config/agid/sync/language.content_settings.node.news.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: node.news
 target_entity_type_id: node
 target_bundle: news

--- a/config/agid/sync/language.content_settings.node.page.yml
+++ b/config/agid/sync/language.content_settings.node.page.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: node.page
 target_entity_type_id: node
 target_bundle: page

--- a/config/agid/sync/language.content_settings.node.pagopa.yml
+++ b/config/agid/sync/language.content_settings.node.pagopa.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: node.pagopa
 target_entity_type_id: node
 target_bundle: pagopa

--- a/config/agid/sync/language.content_settings.node.person.yml
+++ b/config/agid/sync/language.content_settings.node.person.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: node.person
 target_entity_type_id: node
 target_bundle: person

--- a/config/agid/sync/language.content_settings.node.press.yml
+++ b/config/agid/sync/language.content_settings.node.press.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: node.press
 target_entity_type_id: node
 target_bundle: press

--- a/config/agid/sync/language.content_settings.node.software.yml
+++ b/config/agid/sync/language.content_settings.node.software.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: node.software
 target_entity_type_id: node
 target_bundle: software

--- a/config/agid/sync/language.content_settings.paragraph.external_link.yml
+++ b/config/agid/sync/language.content_settings.paragraph.external_link.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: paragraph.external_link
 target_entity_type_id: paragraph
 target_bundle: external_link

--- a/config/agid/sync/language.content_settings.paragraph.image_description.yml
+++ b/config/agid/sync/language.content_settings.paragraph.image_description.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: paragraph.image_description
 target_entity_type_id: paragraph
 target_bundle: image_description

--- a/config/agid/sync/language.content_settings.paragraph.more_info.yml
+++ b/config/agid/sync/language.content_settings.paragraph.more_info.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: paragraph.more_info
 target_entity_type_id: paragraph
 target_bundle: more_info

--- a/config/agid/sync/language.content_settings.paragraph.person_position.yml
+++ b/config/agid/sync/language.content_settings.paragraph.person_position.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: paragraph.person_position
 target_entity_type_id: paragraph
 target_bundle: person_position

--- a/config/agid/sync/language.content_settings.paragraph.title_text.yml
+++ b/config/agid/sync/language.content_settings.paragraph.title_text.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: paragraph.title_text
 target_entity_type_id: paragraph
 target_bundle: title_text

--- a/config/agid/sync/language.content_settings.taxonomy_term.acc_subj_type.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.acc_subj_type.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.acc_subj_type
 target_entity_type_id: taxonomy_term
 target_bundle: acc_subj_type

--- a/config/agid/sync/language.content_settings.taxonomy_term.agid_offices.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.agid_offices.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.agid_offices
 target_entity_type_id: taxonomy_term
 target_bundle: agid_offices

--- a/config/agid/sync/language.content_settings.taxonomy_term.arguments.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.arguments.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.arguments
 target_entity_type_id: taxonomy_term
 target_bundle: arguments

--- a/config/agid/sync/language.content_settings.taxonomy_term.cad.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.cad.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.cad
 target_entity_type_id: taxonomy_term
 target_bundle: cad

--- a/config/agid/sync/language.content_settings.taxonomy_term.contact_form_arguments.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.contact_form_arguments.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.contact_form_arguments
 target_entity_type_id: taxonomy_term
 target_bundle: contact_form_arguments

--- a/config/agid/sync/language.content_settings.taxonomy_term.file_category.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.file_category.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.file_category
 target_entity_type_id: taxonomy_term
 target_bundle: file_category

--- a/config/agid/sync/language.content_settings.taxonomy_term.file_type.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.file_type.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.file_type
 target_entity_type_id: taxonomy_term
 target_bundle: file_type

--- a/config/agid/sync/language.content_settings.taxonomy_term.news_type.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.news_type.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.news_type
 target_entity_type_id: taxonomy_term
 target_bundle: news_type

--- a/config/agid/sync/language.content_settings.taxonomy_term.original_file_source.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.original_file_source.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.original_file_source
 target_entity_type_id: taxonomy_term
 target_bundle: original_file_source

--- a/config/agid/sync/language.content_settings.taxonomy_term.pagopa_type.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.pagopa_type.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.pagopa_type
 target_entity_type_id: taxonomy_term
 target_bundle: pagopa_type

--- a/config/agid/sync/language.content_settings.taxonomy_term.press_release_type.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.press_release_type.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.press_release_type
 target_entity_type_id: taxonomy_term
 target_bundle: press_release_type

--- a/config/agid/sync/language.content_settings.taxonomy_term.profiles.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.profiles.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.profiles
 target_entity_type_id: taxonomy_term
 target_bundle: profiles

--- a/config/agid/sync/language.content_settings.taxonomy_term.roles.yml
+++ b/config/agid/sync/language.content_settings.taxonomy_term.roles.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.roles
 target_entity_type_id: taxonomy_term
 target_bundle: roles

--- a/config/agid/sync/language.content_settings.user.user.yml
+++ b/config/agid/sync/language.content_settings.user.user.yml
@@ -8,6 +8,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: user.user
 target_entity_type_id: user
 target_bundle: user


### PR DESCRIPTION
### Note di deploy
* Effettuare importazione delle configurazioni
    * **bin/drupal ci**
* Effettuare pulizia delle cache
    * **bin/drupal cr all**