### PR TITLE
 AGID-356 Configurare CMS per invio mail (t5HQoxT3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -167,7 +167,8 @@
     "drupal/share_everywhere": "^1.1",
     "drupal/better_exposed_filters": "^3.0@alpha",
     "dompdf/dompdf": "^0.8.2",
-    "drupal/mimemail": "^1.0@alpha"
+    "drupal/mimemail": "^1.0@alpha",
+    "drupal/mailsystem": "^4.1"
   },
   "require-dev": {
     "phing/phing": "2.12.*",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "757c036f102301248033c36ca9da2c8a",
+    "content-hash": "85e73ea94e0ab2652f3e3cee8abfd31d",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -4032,7 +4032,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1522572784",
+                    "datestamp": "1531328711",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/agid/sync/core.base_field_override.node.candidatura.promote.yml
+++ b/config/agid/sync/core.base_field_override.node.candidatura.promote.yml
@@ -1,0 +1,22 @@
+uuid: 856e5873-e5df-4d63-b5e0-510305b63eaa
+langcode: it
+status: true
+dependencies:
+  config:
+    - node.type.candidatura
+id: node.candidatura.promote
+field_name: promote
+entity_type: node
+bundle: candidatura
+label: 'Promosso alla prima pagina'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Acceso
+  off_label: Spento
+field_type: boolean

--- a/config/agid/sync/core.entity_form_display.node.candidatura.default.yml
+++ b/config/agid/sync/core.entity_form_display.node.candidatura.default.yml
@@ -3,6 +3,14 @@ langcode: it
 status: true
 dependencies:
   config:
+    - field.field.node.candidatura.field_citta
+    - field.field.node.candidatura.field_cognome
+    - field.field.node.candidatura.field_email
+    - field.field.node.candidatura.field_identificativo
+    - field.field.node.candidatura.field_indirizzo
+    - field.field.node.candidatura.field_nazionalita
+    - field.field.node.candidatura.field_nome
+    - field.field.node.candidatura.field_regione
     - node.type.candidatura
   module:
     - content_moderation
@@ -18,6 +26,70 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_citta:
+    weight: 125
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_cognome:
+    weight: 122
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_email:
+    weight: 127
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: email_default
+    region: content
+  field_identificativo:
+    weight: 128
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_indirizzo:
+    weight: 124
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_nazionalita:
+    weight: 123
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_nome:
+    weight: 121
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_regione:
+    weight: 126
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   langcode:
     type: language_select
     weight: 2

--- a/config/agid/sync/core.entity_form_display.node.candidatura.default.yml
+++ b/config/agid/sync/core.entity_form_display.node.candidatura.default.yml
@@ -1,0 +1,81 @@
+uuid: e20b1091-9ece-4710-9996-92c2faa44cf6
+langcode: it
+status: true
+dependencies:
+  config:
+    - node.type.candidatura
+  module:
+    - content_moderation
+    - path
+id: node.candidatura.default
+targetEntityType: node
+bundle: candidatura
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+hidden: {  }

--- a/config/agid/sync/core.entity_form_display.user.user.default.yml
+++ b/config/agid/sync/core.entity_form_display.user.user.default.yml
@@ -1,0 +1,93 @@
+uuid: 8587dcf7-1042-4369-9598-ab081b3bdd47
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.field.user.user.field_citta
+    - field.field.user.user.field_cognome
+    - field.field.user.user.field_email
+    - field.field.user.user.field_indirizzo
+    - field.field.user.user.field_nazionalita
+    - field.field.user.user.field_nome
+    - field.field.user.user.field_regione
+  module:
+    - path
+    - user
+id: user.user.default
+targetEntityType: user
+bundle: user
+mode: default
+content:
+  account:
+    weight: -10
+    region: content
+  field_citta:
+    weight: 36
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_cognome:
+    weight: 32
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_email:
+    weight: 37
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: email_default
+    region: content
+  field_indirizzo:
+    weight: 34
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_nazionalita:
+    weight: 33
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_nome:
+    weight: 31
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_regione:
+    weight: 35
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  language:
+    weight: 0
+    region: content
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  timezone:
+    weight: 6
+    region: content
+hidden:
+  langcode: true

--- a/config/agid/sync/core.entity_form_display.user.user.default.yml
+++ b/config/agid/sync/core.entity_form_display.user.user.default.yml
@@ -7,7 +7,7 @@ dependencies:
     - field.field.user.user.field_cognome
     - field.field.user.user.field_email
     - field.field.user.user.field_indirizzo
-    - field.field.user.user.field_nazionalita
+    - field.field.user.user.field_nazionalita_di_residenza
     - field.field.user.user.field_nome
     - field.field.user.user.field_regione
   module:
@@ -53,8 +53,8 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  field_nazionalita:
-    weight: 33
+  field_nazionalita_di_residenza:
+    weight: 38
     settings:
       size: 60
       placeholder: ''

--- a/config/agid/sync/core.entity_view_display.node.candidatura.default.yml
+++ b/config/agid/sync/core.entity_view_display.node.candidatura.default.yml
@@ -3,6 +3,14 @@ langcode: it
 status: true
 dependencies:
   config:
+    - field.field.node.candidatura.field_citta
+    - field.field.node.candidatura.field_cognome
+    - field.field.node.candidatura.field_email
+    - field.field.node.candidatura.field_identificativo
+    - field.field.node.candidatura.field_indirizzo
+    - field.field.node.candidatura.field_nazionalita
+    - field.field.node.candidatura.field_nome
+    - field.field.node.candidatura.field_regione
     - node.type.candidatura
   module:
     - user
@@ -13,6 +21,69 @@ mode: default
 content:
   content_moderation_control:
     weight: -20
+    region: content
+  field_citta:
+    weight: 105
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_cognome:
+    weight: 102
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_email:
+    weight: 107
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_identificativo:
+    weight: 108
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_indirizzo:
+    weight: 104
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_nazionalita:
+    weight: 103
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_nome:
+    weight: 101
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_regione:
+    weight: 106
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   links:
     weight: 100

--- a/config/agid/sync/core.entity_view_display.node.candidatura.default.yml
+++ b/config/agid/sync/core.entity_view_display.node.candidatura.default.yml
@@ -1,0 +1,21 @@
+uuid: 8829bec6-a984-4f03-a7e4-cb4ed5dc6c0b
+langcode: it
+status: true
+dependencies:
+  config:
+    - node.type.candidatura
+  module:
+    - user
+id: node.candidatura.default
+targetEntityType: node
+bundle: candidatura
+mode: default
+content:
+  content_moderation_control:
+    weight: -20
+    region: content
+  links:
+    weight: 100
+    region: content
+hidden:
+  langcode: true

--- a/config/agid/sync/core.entity_view_display.node.candidatura.teaser.yml
+++ b/config/agid/sync/core.entity_view_display.node.candidatura.teaser.yml
@@ -19,4 +19,12 @@ content:
     weight: 100
     region: content
 hidden:
+  field_citta: true
+  field_cognome: true
+  field_email: true
+  field_identificativo: true
+  field_indirizzo: true
+  field_nazionalita: true
+  field_nome: true
+  field_regione: true
   langcode: true

--- a/config/agid/sync/core.entity_view_display.node.candidatura.teaser.yml
+++ b/config/agid/sync/core.entity_view_display.node.candidatura.teaser.yml
@@ -1,0 +1,22 @@
+uuid: 8566bca8-8b35-4cbc-9bca-87f903cd1b0c
+langcode: it
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.candidatura
+  module:
+    - user
+id: node.candidatura.teaser
+targetEntityType: node
+bundle: candidatura
+mode: teaser
+content:
+  content_moderation_control:
+    weight: -20
+    region: content
+  links:
+    weight: 100
+    region: content
+hidden:
+  langcode: true

--- a/config/agid/sync/core.entity_view_display.user.user.default.yml
+++ b/config/agid/sync/core.entity_view_display.user.user.default.yml
@@ -1,0 +1,79 @@
+uuid: d5568c26-a089-4569-b1cd-1132f3470f21
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.field.user.user.field_citta
+    - field.field.user.user.field_cognome
+    - field.field.user.user.field_email
+    - field.field.user.user.field_indirizzo
+    - field.field.user.user.field_nazionalita
+    - field.field.user.user.field_nome
+    - field.field.user.user.field_regione
+  module:
+    - user
+id: user.user.default
+targetEntityType: user
+bundle: user
+mode: default
+content:
+  field_citta:
+    weight: 11
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_cognome:
+    weight: 7
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_email:
+    weight: 12
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_indirizzo:
+    weight: 9
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_nazionalita:
+    weight: 8
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_nome:
+    weight: 6
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_regione:
+    weight: 10
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  member_for:
+    weight: 5
+    region: content
+hidden:
+  langcode: true

--- a/config/agid/sync/core.entity_view_display.user.user.default.yml
+++ b/config/agid/sync/core.entity_view_display.user.user.default.yml
@@ -7,7 +7,7 @@ dependencies:
     - field.field.user.user.field_cognome
     - field.field.user.user.field_email
     - field.field.user.user.field_indirizzo
-    - field.field.user.user.field_nazionalita
+    - field.field.user.user.field_nazionalita_di_residenza
     - field.field.user.user.field_nome
     - field.field.user.user.field_regione
   module:
@@ -48,8 +48,8 @@ content:
     third_party_settings: {  }
     type: string
     region: content
-  field_nazionalita:
-    weight: 8
+  field_nazionalita_di_residenza:
+    weight: 13
     label: above
     settings:
       link_to_entity: false

--- a/config/agid/sync/core.extension.yml
+++ b/config/agid/sync/core.extension.yml
@@ -22,6 +22,7 @@ module:
   block_titlelink: 0
   breakpoint: 0
   broken_link: 0
+  candidatura_mentor: 0
   captcha: 0
   chosen: 0
   chosen_lib: 0

--- a/config/agid/sync/extlink.settings.yml
+++ b/config/agid/sync/extlink.settings.yml
@@ -11,3 +11,4 @@ extlink_css_exclude: "header, .Footer\r\n"
 extlink_css_explicit: "main\r\n"
 extlink_label: '(link is external)'
 extlink_mailto_label: '(link sends email)'
+langcode: it

--- a/config/agid/sync/field.field.node.candidatura.field_citta.yml
+++ b/config/agid/sync/field.field.node.candidatura.field_citta.yml
@@ -1,0 +1,19 @@
+uuid: 75e3a5dd-94a0-496c-8b39-ef518cb192fa
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_citta
+    - node.type.candidatura
+id: node.candidatura.field_citta
+field_name: field_citta
+entity_type: node
+bundle: candidatura
+label: Città
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.node.candidatura.field_cognome.yml
+++ b/config/agid/sync/field.field.node.candidatura.field_cognome.yml
@@ -1,0 +1,19 @@
+uuid: 8850cef7-764a-4ba7-8877-b0663e4debda
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_cognome
+    - node.type.candidatura
+id: node.candidatura.field_cognome
+field_name: field_cognome
+entity_type: node
+bundle: candidatura
+label: Cognome
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.node.candidatura.field_email.yml
+++ b/config/agid/sync/field.field.node.candidatura.field_email.yml
@@ -1,0 +1,19 @@
+uuid: a2817a9f-4d5e-4faf-be0c-92c1f2f6806e
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_email
+    - node.type.candidatura
+id: node.candidatura.field_email
+field_name: field_email
+entity_type: node
+bundle: candidatura
+label: Email
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/config/agid/sync/field.field.node.candidatura.field_identificativo.yml
+++ b/config/agid/sync/field.field.node.candidatura.field_identificativo.yml
@@ -1,0 +1,19 @@
+uuid: ba86e8c3-5024-42d1-a404-cb8bd93774dd
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_identificativo
+    - node.type.candidatura
+id: node.candidatura.field_identificativo
+field_name: field_identificativo
+entity_type: node
+bundle: candidatura
+label: Identificativo
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.node.candidatura.field_indirizzo.yml
+++ b/config/agid/sync/field.field.node.candidatura.field_indirizzo.yml
@@ -1,0 +1,19 @@
+uuid: 9e230f3b-49d3-49df-9904-7269f2195f61
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_indirizzo
+    - node.type.candidatura
+id: node.candidatura.field_indirizzo
+field_name: field_indirizzo
+entity_type: node
+bundle: candidatura
+label: Indirizzo
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.node.candidatura.field_nazionalita.yml
+++ b/config/agid/sync/field.field.node.candidatura.field_nazionalita.yml
@@ -1,0 +1,19 @@
+uuid: b3006f38-a797-4892-a359-fbb7fa15139e
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_nazionalita
+    - node.type.candidatura
+id: node.candidatura.field_nazionalita
+field_name: field_nazionalita
+entity_type: node
+bundle: candidatura
+label: Nazionalità
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.node.candidatura.field_nome.yml
+++ b/config/agid/sync/field.field.node.candidatura.field_nome.yml
@@ -1,0 +1,19 @@
+uuid: 3d0c6c57-5e59-4809-95a2-586082a49f96
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_nome
+    - node.type.candidatura
+id: node.candidatura.field_nome
+field_name: field_nome
+entity_type: node
+bundle: candidatura
+label: Nome
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.node.candidatura.field_regione.yml
+++ b/config/agid/sync/field.field.node.candidatura.field_regione.yml
@@ -1,0 +1,19 @@
+uuid: 7e86f048-b642-495e-9064-1282debcea9e
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_regione
+    - node.type.candidatura
+id: node.candidatura.field_regione
+field_name: field_regione
+entity_type: node
+bundle: candidatura
+label: Regione
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.user.user.field_citta.yml
+++ b/config/agid/sync/field.field.user.user.field_citta.yml
@@ -1,0 +1,20 @@
+uuid: 8095211b-f0b2-408c-86b6-abf544f96cd9
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_citta
+  module:
+    - user
+id: user.user.field_citta
+field_name: field_citta
+entity_type: user
+bundle: user
+label: Città
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.user.user.field_cognome.yml
+++ b/config/agid/sync/field.field.user.user.field_cognome.yml
@@ -1,0 +1,20 @@
+uuid: 845d4039-1096-42c3-b6cc-c0bc17130fff
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_cognome
+  module:
+    - user
+id: user.user.field_cognome
+field_name: field_cognome
+entity_type: user
+bundle: user
+label: Cognome
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.user.user.field_email.yml
+++ b/config/agid/sync/field.field.user.user.field_email.yml
@@ -1,0 +1,20 @@
+uuid: 5550a691-425a-4050-847d-31921ae14318
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_email
+  module:
+    - user
+id: user.user.field_email
+field_name: field_email
+entity_type: user
+bundle: user
+label: Email
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/config/agid/sync/field.field.user.user.field_indirizzo.yml
+++ b/config/agid/sync/field.field.user.user.field_indirizzo.yml
@@ -1,0 +1,20 @@
+uuid: 6611d1a3-9bcf-4d95-840a-af312a38faf2
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_indirizzo
+  module:
+    - user
+id: user.user.field_indirizzo
+field_name: field_indirizzo
+entity_type: user
+bundle: user
+label: Indirizzo
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.user.user.field_nazionalita.yml
+++ b/config/agid/sync/field.field.user.user.field_nazionalita.yml
@@ -1,0 +1,20 @@
+uuid: eb869dd9-11e9-4421-8da4-feb722850539
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_nazionalita
+  module:
+    - user
+id: user.user.field_nazionalita
+field_name: field_nazionalita
+entity_type: user
+bundle: user
+label: Nazionalità
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.user.user.field_nazionalita_di_residenza.yml
+++ b/config/agid/sync/field.field.user.user.field_nazionalita_di_residenza.yml
@@ -1,16 +1,16 @@
-uuid: eb869dd9-11e9-4421-8da4-feb722850539
+uuid: 36ffc2bf-3b6c-4591-99d9-f2a3f150b30b
 langcode: it
 status: true
 dependencies:
   config:
-    - field.storage.user.field_nazionalita
+    - field.storage.user.field_nazionalita_di_residenza
   module:
     - user
-id: user.user.field_nazionalita
-field_name: field_nazionalita
+id: user.user.field_nazionalita_di_residenza
+field_name: field_nazionalita_di_residenza
 entity_type: user
 bundle: user
-label: Nazionalità
+label: 'Nazionalità di residenza'
 description: ''
 required: false
 translatable: false

--- a/config/agid/sync/field.field.user.user.field_nome.yml
+++ b/config/agid/sync/field.field.user.user.field_nome.yml
@@ -1,0 +1,20 @@
+uuid: aa08ce10-c8d3-420e-9bc5-f29666355280
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_nome
+  module:
+    - user
+id: user.user.field_nome
+field_name: field_nome
+entity_type: user
+bundle: user
+label: Nome
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.field.user.user.field_regione.yml
+++ b/config/agid/sync/field.field.user.user.field_regione.yml
@@ -1,0 +1,20 @@
+uuid: 9a9190be-3b59-4443-9ed4-ce011fa16170
+langcode: it
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_regione
+  module:
+    - user
+id: user.user.field_regione
+field_name: field_regione
+entity_type: user
+bundle: user
+label: Regione
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/agid/sync/field.storage.node.field_citta.yml
+++ b/config/agid/sync/field.storage.node.field_citta.yml
@@ -1,0 +1,21 @@
+uuid: 3b329327-3b33-4e86-9bab-dd61cf6c7409
+langcode: it
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_citta
+field_name: field_citta
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.node.field_cognome.yml
+++ b/config/agid/sync/field.storage.node.field_cognome.yml
@@ -1,0 +1,21 @@
+uuid: 429b9caf-af2d-4ece-bf19-70db1cea729e
+langcode: it
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_cognome
+field_name: field_cognome
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.node.field_email.yml
+++ b/config/agid/sync/field.storage.node.field_email.yml
@@ -1,0 +1,18 @@
+uuid: 422a11dc-0591-496d-865f-b6bf5af51c31
+langcode: it
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_email
+field_name: field_email
+entity_type: node
+type: email
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.node.field_identificativo.yml
+++ b/config/agid/sync/field.storage.node.field_identificativo.yml
@@ -1,0 +1,21 @@
+uuid: fb0fe152-05cb-4b37-8e42-2f6aabd528bf
+langcode: it
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_identificativo
+field_name: field_identificativo
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.node.field_indirizzo.yml
+++ b/config/agid/sync/field.storage.node.field_indirizzo.yml
@@ -1,0 +1,21 @@
+uuid: dc09bc28-9c81-4579-8a2c-2ba402fc58cc
+langcode: it
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_indirizzo
+field_name: field_indirizzo
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.node.field_nazionalita.yml
+++ b/config/agid/sync/field.storage.node.field_nazionalita.yml
@@ -1,0 +1,21 @@
+uuid: 2b3fcf12-4408-426f-bc0a-03dc62dd8bc0
+langcode: it
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_nazionalita
+field_name: field_nazionalita
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.node.field_nome.yml
+++ b/config/agid/sync/field.storage.node.field_nome.yml
@@ -1,0 +1,21 @@
+uuid: 88608003-d025-4c5e-8636-0efbb1f806ae
+langcode: it
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_nome
+field_name: field_nome
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.node.field_regione.yml
+++ b/config/agid/sync/field.storage.node.field_regione.yml
@@ -1,0 +1,21 @@
+uuid: 55949cba-a867-4f80-9a55-729bdf8b3c26
+langcode: it
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_regione
+field_name: field_regione
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.user.field_citta.yml
+++ b/config/agid/sync/field.storage.user.field_citta.yml
@@ -1,0 +1,21 @@
+uuid: da5119aa-1f0c-4aa4-b709-0b61ed58d8cf
+langcode: it
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_citta
+field_name: field_citta
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.user.field_cognome.yml
+++ b/config/agid/sync/field.storage.user.field_cognome.yml
@@ -1,0 +1,21 @@
+uuid: 71ff5eaa-3998-411a-81e9-e2091d53da86
+langcode: it
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_cognome
+field_name: field_cognome
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.user.field_email.yml
+++ b/config/agid/sync/field.storage.user.field_email.yml
@@ -1,0 +1,18 @@
+uuid: 920909c4-57ab-40af-ab9a-b12fccdc9b78
+langcode: it
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_email
+field_name: field_email
+entity_type: user
+type: email
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.user.field_indirizzo.yml
+++ b/config/agid/sync/field.storage.user.field_indirizzo.yml
@@ -1,0 +1,21 @@
+uuid: cbfc3fb2-446c-42e7-bd19-aa3171de48c1
+langcode: it
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_indirizzo
+field_name: field_indirizzo
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.user.field_nazionalita.yml
+++ b/config/agid/sync/field.storage.user.field_nazionalita.yml
@@ -1,0 +1,21 @@
+uuid: 5db97478-0ad8-49a5-b92c-fb93b633e137
+langcode: it
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_nazionalita
+field_name: field_nazionalita
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.user.field_nazionalita_di_residenza.yml
+++ b/config/agid/sync/field.storage.user.field_nazionalita_di_residenza.yml
@@ -1,11 +1,11 @@
-uuid: 5db97478-0ad8-49a5-b92c-fb93b633e137
+uuid: 516cbbc3-0cbb-47e0-91f3-456277097420
 langcode: it
 status: true
 dependencies:
   module:
     - user
-id: user.field_nazionalita
-field_name: field_nazionalita
+id: user.field_nazionalita_di_residenza
+field_name: field_nazionalita_di_residenza
 entity_type: user
 type: string
 settings:

--- a/config/agid/sync/field.storage.user.field_nome.yml
+++ b/config/agid/sync/field.storage.user.field_nome.yml
@@ -1,0 +1,21 @@
+uuid: 2bd386c1-aa0a-4a43-a7c7-e2e69f3c333d
+langcode: it
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_nome
+field_name: field_nome
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/field.storage.user.field_regione.yml
+++ b/config/agid/sync/field.storage.user.field_regione.yml
@@ -1,0 +1,21 @@
+uuid: faebf905-29df-4470-808c-735bed774599
+langcode: it
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_regione
+field_name: field_regione
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/agid/sync/language.content_settings.node.candidatura.yml
+++ b/config/agid/sync/language.content_settings.node.candidatura.yml
@@ -1,0 +1,11 @@
+uuid: 73dda8de-5976-4439-ae95-6e718412cb93
+langcode: it
+status: true
+dependencies:
+  config:
+    - node.type.candidatura
+id: node.candidatura
+target_entity_type_id: node
+target_bundle: candidatura
+default_langcode: site_default
+language_alterable: false

--- a/config/agid/sync/mailsystem.settings.yml
+++ b/config/agid/sync/mailsystem.settings.yml
@@ -1,0 +1,5 @@
+defaults:
+  formatter: SMTPMailSystem
+  sender: SMTPMailSystem
+theme: current
+langcode: it

--- a/config/agid/sync/migrate_drupal.settings.yml
+++ b/config/agid/sync/migrate_drupal.settings.yml
@@ -1,3 +1,4 @@
 enforce_source_module_tags:
   - 'Drupal 6'
   - 'Drupal 7'
+langcode: it

--- a/config/agid/sync/node.type.candidatura.yml
+++ b/config/agid/sync/node.type.candidatura.yml
@@ -1,0 +1,18 @@
+uuid: 30284204-cf09-4319-bdbb-eb16f3f57cba
+langcode: it
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: Candidatura
+type: candidatura
+description: 'Candidatura mentor'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: true

--- a/config/agid/sync/redirect.settings.yml
+++ b/config/agid/sync/redirect.settings.yml
@@ -5,3 +5,4 @@ default_status_code: 301
 route_normalizer_enabled: false
 ignore_admin_path: false
 access_check: false
+langcode: it

--- a/config/agid/sync/smtp.settings.yml
+++ b/config/agid/sync/smtp.settings.yml
@@ -1,10 +1,10 @@
 smtp_on: true
-smtp_host: smtp.agid.gov.it
+smtp_host: smtp.gmail.com
 smtp_hostbackup: ''
 smtp_port: '465'
 smtp_protocol: ssl
-smtp_username: TEST@MAIL.COM
-smtp_password: TEST
+smtp_username: test@dev.com
+smtp_password: testpass
 smtp_from: no-reply@agid.gov.it
 smtp_fromname: AgID
 smtp_client_hostname: ''

--- a/config/agid/sync/smtp.settings.yml
+++ b/config/agid/sync/smtp.settings.yml
@@ -1,10 +1,10 @@
 smtp_on: true
 smtp_host: smtp.agid.gov.it
 smtp_hostbackup: ''
-smtp_port: '26'
-smtp_protocol: standard
-smtp_username: ''
-smtp_password: ''
+smtp_port: '465'
+smtp_protocol: ssl
+smtp_username: TEST@MAIL.COM
+smtp_password: TEST
 smtp_from: no-reply@agid.gov.it
 smtp_fromname: AgID
 smtp_client_hostname: ''

--- a/config/agid/sync/system.action.user_add_role_action.operatore_marocco.yml
+++ b/config/agid/sync/system.action.user_add_role_action.operatore_marocco.yml
@@ -1,0 +1,14 @@
+uuid: 9b0bd4b7-a079-433b-af56-d9a6c1dffb54
+langcode: it
+status: true
+dependencies:
+  config:
+    - user.role.operatore_marocco
+  module:
+    - user
+id: user_add_role_action.operatore_marocco
+label: 'Add the operatore_marocco role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: operatore_marocco

--- a/config/agid/sync/system.action.user_add_role_action.operatore_tunisia.yml
+++ b/config/agid/sync/system.action.user_add_role_action.operatore_tunisia.yml
@@ -1,0 +1,14 @@
+uuid: d636cc4d-a819-4bc2-978d-b11b8133bc14
+langcode: it
+status: true
+dependencies:
+  config:
+    - user.role.operatore_tunisia
+  module:
+    - user
+id: user_add_role_action.operatore_tunisia
+label: 'Add the Operatore Tunisia role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: operatore_tunisia

--- a/config/agid/sync/system.action.user_remove_role_action.operatore_marocco.yml
+++ b/config/agid/sync/system.action.user_remove_role_action.operatore_marocco.yml
@@ -1,0 +1,14 @@
+uuid: 2e521cef-7dc4-4be9-8b94-cadb2005327b
+langcode: it
+status: true
+dependencies:
+  config:
+    - user.role.operatore_marocco
+  module:
+    - user
+id: user_remove_role_action.operatore_marocco
+label: 'Remove the operatore_marocco role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: operatore_marocco

--- a/config/agid/sync/system.action.user_remove_role_action.operatore_tunisia.yml
+++ b/config/agid/sync/system.action.user_remove_role_action.operatore_tunisia.yml
@@ -1,0 +1,14 @@
+uuid: 53e80f50-0af0-4d0a-a4a3-8a5e99538839
+langcode: it
+status: true
+dependencies:
+  config:
+    - user.role.operatore_tunisia
+  module:
+    - user
+id: user_remove_role_action.operatore_tunisia
+label: 'Remove the Operatore Tunisia role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: operatore_tunisia

--- a/config/agid/sync/user.role.operatore_marocco.yml
+++ b/config/agid/sync/user.role.operatore_marocco.yml
@@ -6,4 +6,13 @@ id: operatore_marocco
 label: operatore_marocco
 weight: -4
 is_admin: null
-permissions: {  }
+permissions:
+  - 'access administration pages'
+  - 'access content overview'
+  - 'access toolbar'
+  - 'create candidatura content'
+  - 'edit own candidatura content'
+  - 'use b8448396 transition complete'
+  - 'use b8448396 transition draft_draft'
+  - 'use b8448396 transition published_draft'
+  - 'view the administration theme'

--- a/config/agid/sync/user.role.operatore_marocco.yml
+++ b/config/agid/sync/user.role.operatore_marocco.yml
@@ -1,0 +1,9 @@
+uuid: bfc8b73b-097d-45d7-ae2f-668e796897c0
+langcode: it
+status: true
+dependencies: {  }
+id: operatore_marocco
+label: operatore_marocco
+weight: -4
+is_admin: null
+permissions: {  }

--- a/config/agid/sync/user.role.operatore_tunisia.yml
+++ b/config/agid/sync/user.role.operatore_tunisia.yml
@@ -1,10 +1,10 @@
-uuid: bfc8b73b-097d-45d7-ae2f-668e796897c0
+uuid: 9ea19233-c585-4262-8c1c-0b186b14256c
 langcode: it
 status: true
 dependencies: {  }
-id: operatore_marocco
-label: 'Operatore Marocco'
-weight: -4
+id: operatore_tunisia
+label: 'Operatore Tunisia'
+weight: -3
 is_admin: null
 permissions:
   - 'access administration pages'

--- a/config/agid/sync/workflows.workflow.b8448396.yml
+++ b/config/agid/sync/workflows.workflow.b8448396.yml
@@ -17,6 +17,11 @@ type_settings:
       default_revision: true
       label: Archiviato
       weight: 4
+    complete:
+      published: true
+      default_revision: false
+      label: Completo
+      weight: 5
     draft:
       label: Bozza
       published: false
@@ -33,6 +38,12 @@ type_settings:
       default_revision: true
       weight: 3
   transitions:
+    complete:
+      label: Completo
+      from:
+        - draft
+      to: complete
+      weight: 11
     draft_draft:
       label: 'Create New Draft'
       from:

--- a/config/agid/sync/workflows.workflow.b8448396.yml
+++ b/config/agid/sync/workflows.workflow.b8448396.yml
@@ -3,6 +3,7 @@ langcode: it
 status: true
 dependencies:
   config:
+    - node.type.candidatura
     - node.type.page
   module:
     - content_moderation
@@ -96,4 +97,5 @@ type_settings:
       weight: 9
   entity_types:
     node:
+      - candidatura
       - page

--- a/web/modules/custom/candidatura_mentor/candidatura_mentor.info.yml
+++ b/web/modules/custom/candidatura_mentor/candidatura_mentor.info.yml
@@ -1,0 +1,4 @@
+name: AGID Candidatura Mentor
+core: 8.x
+type: module
+package: Custom

--- a/web/modules/custom/candidatura_mentor/candidatura_mentor.module
+++ b/web/modules/custom/candidatura_mentor/candidatura_mentor.module
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * @file
+ * Main hooks for Candidatura Mentor module.
+ */
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Database\Database;
+use Drupal\Component\Utility\SafeMarkup;
+use Drupal\user\Entity\User;
+use Drupal\Core\Access\AccessResult;
+
+function candidatura_mentor_entity_presave(EntityInterface $entity) {
+  if($entity->isNew() && $entity->bundle() == 'candidatura') {
+    $id = candidatura_mentor_get_next_id_number();
+    $entity->set('field_identificativo', 'CAND-'.$id);
+  }
+}
+
+function candidatura_mentor_get_next_id_number(){
+  $database = \Drupal::database();
+  $countCandidatura = $database->select('node__field_identificativo', 'n')
+    ->condition('n.bundle', 'candidatura', '=')
+    ->countQuery()
+    ->execute()
+    ->fetchField();
+  return $countCandidatura+1;
+}
+
+function candidatura_mentor_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  $uid = \Drupal::currentUser()->id();
+  $user = \Drupal\user\Entity\User::load($uid);
+  $roles = $user->getRoles();
+
+  if ($form_id == 'node_candidatura_form'){
+    $form['field_identificativo']['#disabled'] = TRUE;
+    $form['field_identificativo']['#type'] = 'hidden';
+    $form['field_nome']['widget'][0]['value']['#default_value'] = $user->field_nome->value;
+    $form['field_cognome']['widget'][0]['value']['#default_value'] = $user->field_cognome->value;
+    $form['field_nazionalita']['widget'][0]['value']['#default_value'] = ucfirst($user->field_nazionalita_di_residenza->value);
+    $form['field_indirizzo']['widget'][0]['value']['#default_value'] = $user->field_indirizzo->value;
+    $form['field_citta']['widget'][0]['value']['#default_value'] = $user->field_citta->value;
+    $form['field_regione']['widget'][0]['value']['#default_value'] = $user->field_regione->value;
+    $form['field_email']['widget'][0]['value']['#default_value'] = $user->mail->value;
+  }
+
+  if ($form_id == 'node_candidatura_form' || $form_id == 'node_candidatura_edit_form'){
+    $form['field_identificativo']['#disabled'] = TRUE;
+    $form['field_nome']['#disabled'] = TRUE;
+    $form['field_cognome']['#disabled'] = TRUE;
+    $form['field_nazionalita']['#disabled'] = TRUE;
+    $form['field_indirizzo']['#disabled'] = TRUE;
+    $form['field_citta']['#disabled'] = TRUE;
+    $form['field_regione']['#disabled'] = TRUE;
+    $form['field_email']['#disabled'] = TRUE;
+  }
+
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function candidatura_mentor_entity_insert(Drupal\Core\Entity\EntityInterface $entity) {
+
+  if ($entity->getEntityTypeId() == 'node' && $entity->bundle() == 'candidatura'){
+
+    $currentState = $entity->get('moderation_state')->value;
+    if ($currentState == 'complete'){
+
+      $candidaturaArg = array();
+      $candidaturaArg['title'] = $entity->label();
+      $host = \Drupal::request()->getHost();
+      $candidaturaArg['url'] = $host . $entity->toUrl()->toString();
+
+      $nationality = $entity->get('field_nazionalita')->value;
+      switch ($nationality){
+        case 'Marocco':
+          $emailList = _candidatura_mentor_getEmailList('operatore_marocco');
+          break;
+
+        case 'Tunisia':
+          $emailList = _candidatura_mentor_getEmailList('operatore_tunisia');
+          break;
+
+      }
+
+      if (!empty($emailList)){
+        foreach ($emailList as $email) {
+          print $email;
+          _candidatura_mentor_sendEmail($email, 'complete_content', $candidaturaArg);
+        }
+      }
+
+    }
+
+  }
+}
+
+function candidatura_mentor_entity_update(EntityInterface $entity) {
+  if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'candidatura'){
+    $originalState = $entity->original->get('moderation_state')->value;
+    $currentState = $entity->get('moderation_state')->value;
+    $candidaturaArg = array();
+    $candidaturaArg['title'] = $entity->label();
+    $host = \Drupal::request()->getHost();
+    $candidaturaArg['url'] = $host . $entity->toUrl()->toString();
+
+    if ($originalState == 'draft' && $currentState == 'complete'){
+      $nationality = $entity->get('field_nazionalita')->value;
+      switch ($nationality){
+        case 'Marocco':
+          $emailList = _candidatura_mentor_getEmailList('operatore_marocco');
+          break;
+
+        case 'Tunisia':
+          $emailList = _candidatura_mentor_getEmailList('operatore_tunisia');
+          break;
+
+      }
+
+      if (!empty($emailList)){
+        foreach ($emailList as $email) {
+          print $email;
+          _candidatura_mentor_sendEmail($email, 'complete_content', $candidaturaArg);
+        }
+      }
+
+    }elseif ($originalState == 'complete' && $currentState == 'published'){
+      $emailAuthor = $entity->getOwner()->get('mail')->value;
+      if(!empty($emailAuthor)){
+        _candidatura_mentor_sendEmail($emailAuthor, 'publish_content', $candidaturaArg);
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_mail().
+ */
+function candidatura_mentor_mail($key, &$message, $params) {
+  $options = array(
+    'langcode' => $message['langcode'],
+  );
+  switch ($key) {
+    case 'publish_content':
+      $message['from'] = \Drupal::config('system.site')->get('mail');
+      $message['subject'] = t('MENTOR - Candidatura pubblicata: @title', array('@title' => $params['node_title']), $options);
+      $message['body'][] = t('La tua candidatura &egrave; stata pubblicata sul nostro sito: @url', array('@url' => $params['url']), $options);
+      break;
+
+    case 'complete_content':
+      $message['from'] = \Drupal::config('system.site')->get('mail');
+      $message['subject'] = t('MENTOR - Inserita nuova candidatura: @title', array('@title' => $params['node_title']), $options);
+      $message['body'][] = t('&Egrave; stata inserita una nuova candidatura: @url',  array('@url' => $params['url']), $options);
+      break;
+
+  }
+
+}
+
+function _candidatura_mentor_sendEmail($to, $key, $args){
+  $mailManager = \Drupal::service('plugin.manager.mail');
+  $module = 'candidatura_mentor';
+
+  $params['message'] = t('La tua candidatura &egrave; stata pubblicata sul nostro sito');
+  $params['node_title'] = $args['title'];
+  $params['url'] = $args['url'];
+  $langcode = \Drupal::currentUser()->getPreferredLangcode();
+  $send = true;
+
+  $result = $mailManager->mail($module, $key, $to, $langcode, $params, NULL, $send);
+}
+
+function _candidatura_mentor_getEmailList($role){
+  $userID = \Drupal::entityQuery('user')
+    ->condition('status', 1)
+    ->condition('roles', $role)
+    ->execute();
+  $users = User::loadMultiple($userID);
+  $usersEmail = array();
+  foreach ($users as &$user) {
+    if ($user->get('mail')->value){
+      array_push($usersEmail, $user->get('mail')->value);
+    }
+  }
+  return $usersEmail;
+}

--- a/web/modules/custom/candidatura_mentor/candidatura_mentor.module
+++ b/web/modules/custom/candidatura_mentor/candidatura_mentor.module
@@ -58,7 +58,6 @@ function candidatura_mentor_form_alter(&$form, FormStateInterface $form_state, $
     $form['field_regione']['#disabled'] = TRUE;
     $form['field_email']['#disabled'] = TRUE;
   }
-
 }
 
 /**


### PR DESCRIPTION
### Desrizione PR
La seguente PR completa ed integra il modulo **candidature_mentor**. Questo si occupa di notificare a tutti gli utenti con ruolo operatore_marocco/operatore_tunisia l'avvenuta creazione di un nodo di tipo "candidatura" il cui campo "Nazionalità" è stato valorizzato o con **Marocco** o con **Tunisia**. Il che significa che l'utente che sta creando il nodo ha il campo (del profilo utente) **Nazionalità di residenza** impostato o con **Marocco** o con **Tunisia**. Infatti il nodo candidatura e il profilo utente sono quasi speculari e i dati presenti nel profilo utente di chi crea il nodo verranno passati automaticamente alla form di creazione della candidatura.

### Cosa prevede la PR
* Aggiunta dei ruoli: operatore_marocco e operatore_tunisia e **relativi permessi**
* Modifica del profilo utente con l'aggiunta di campi custom
* Creazione del tipo di contenuto candidatura

## Deploy
* Installa dipendenze: **composer install --prefer-dist**
* Importa configurazioni: **bin/drupal ci**
* Configurare correttamente SMTP

### Per testare la funzionalità
* Creare un utente di test con ruolo "operatore_marocco" e valorizzarne i campi facendo attenzione al campo "Nazionalità di residenza" che deve essere "Marocco"
* Creare altro utente con ruolo operatore_marocco (per verificare che anche questo riceva la sua mail)
* Loggarsi con l'utente appena creato
* Creare un nodo **candidatura** (titolo può essere qualsiasi) 
* Passare il nodo da **bozza** a **completo**
* Se SMTP è configurato correttamente, verificare l'avvenuta ricezione della mail.

