### PR TITLE
AGID-547 Accessibility issues

### DIFF
--- a/docroot/web/modules/custom/agid_search/agid_search.module
+++ b/docroot/web/modules/custom/agid_search/agid_search.module
@@ -29,7 +29,7 @@ function agid_search_help($route_name, RouteMatchInterface $route_match) {
 function agid_search_theme($existing, $type, $theme, $path) {
   return [
     'agid_search_simple_full_text_search' => [
-      'variables' => ['view_uri' => NULL],
+      'variables' => ['view_uri' => NULL, 'unique_id'=>NULL],
     ],
   ];
 }

--- a/docroot/web/modules/custom/agid_search/src/Plugin/Block/SimpleFullTextSearchBlock.php
+++ b/docroot/web/modules/custom/agid_search/src/Plugin/Block/SimpleFullTextSearchBlock.php
@@ -23,6 +23,7 @@ class SimpleFullTextSearchBlock extends BlockBase {
     $build['agid_search_simple_box_block'] = [
       '#theme' => 'agid_search_simple_full_text_search',
       '#view_uri' => Url::fromRoute('view.search_site.page')->toString(),
+      '#unique_id' => uniqid(),
       '#cache' => [
         'tags' => View::load('search_site')->getCacheTags(),
       ],

--- a/docroot/web/modules/custom/agid_twitter_block/templates/agid-twitter-block.html.twig
+++ b/docroot/web/modules/custom/agid_twitter_block/templates/agid-twitter-block.html.twig
@@ -33,7 +33,7 @@
                     {{ tweet.text }}
                   </h3>
                   <p>
-                    <a title="visualizza su twitter" class="u-color-50 u-textClean u-text-xl" href="{{ tweet.entities.urls[0].url }}">
+                    <a title="visualizza su twitter" class="u-color-50 u-textClean u-text-xl" href="{{ tweet.entities.urls[0].url }}" aria-label="{{tweet.text[:75]}}">
                       <span class="Icon-twitter" aria-hidden="true"></span>
                       <span class="u-hiddenVisually">visualizza su twitter</span>
                     </a>

--- a/docroot/web/themes/custom/agid/templates/block/block--header-top--slimheadermenu.html.twig
+++ b/docroot/web/themes/custom/agid/templates/block/block--header-top--slimheadermenu.html.twig
@@ -58,7 +58,7 @@
   {% endblock %}
 </nav>
 
-<section class="Offcanvas Offcanvas--left Offcanvas--modal js-fr-offcanvas u-jsVisibilityHidden u-nojsDisplayNone u-hiddenPrint" id="slim-menu">
+<section class="Offcanvas Offcanvas--left Offcanvas--modal js-fr-offcanvas u-jsVisibilityHidden u-nojsDisplayNone u-hiddenPrint" id="slim-menu" aria-labelledby="slim-menu-title">
   <h2 id="slim-menu-title" class="u-hiddenVisually">Menu di navigazione</h2>
   <div class="Offcanvas-content u-background-white">
     <div class="Offcanvas-toggleContainer u-background-70 u-jsHidden">
@@ -66,7 +66,7 @@
         <span class="Hamburger-toggle is-active" aria-hidden="true"></span>
       </a>
     </div>
-    <nav>
+    <nav aria-labelledby="slim-menu-title">
       <ul class="Linklist Linklist--padded Treeview Treeview--default js-Treeview u-text-r-xs" aria-labelledby="slim-menu-title">
         {{ content }}
       </ul>

--- a/docroot/web/themes/custom/agid/templates/layout/page--webform.html.twig
+++ b/docroot/web/themes/custom/agid/templates/layout/page--webform.html.twig
@@ -311,7 +311,7 @@
 
       {# Scroll to top #}
       <a title="{{ scrolltop_text }}" class="ScrollTop js-scrollTop js-scrollTo" style="display: none; cursor: pointer">
-        <i class="ScrollTop-icon Icon-collapse" aria-hidden="true"></i>
+        <i class="ScrollTop-icon Icon-collapse" aria-hidden="true" role="img" alt="Scroll to top icon"></i>
         <span class="u-hiddenVisually">{{ scrolltop_text }}</span>
       </a>
   </main>

--- a/docroot/web/themes/custom/agid/templates/layout/page.html.twig
+++ b/docroot/web/themes/custom/agid/templates/layout/page.html.twig
@@ -129,7 +129,7 @@
 
     <div class="Megamenu-wrapper u-textCenter u-hidden u-sm-hidden u-md-block u-lg-block">
       <div class="u-layout-wide u-layoutCenter">
-        <nav class="Megamenu Megamenu--default js-megamenu" data-rel=".Offcanvas--right .Treeview" data-placement="bottom"></nav>
+        <nav class="Megamenu Megamenu--default js-megamenu" data-rel=".Offcanvas--right .Treeview" data-placement="bottom" aria-label="Main menu"></nav>
       </div>
     </div>
 
@@ -308,7 +308,7 @@
 
     {# Scroll to top #}
     <a title="{{ scrolltop_text }}" class="ScrollTop js-scrollTop js-scrollTo" style="display: none; cursor: pointer">
-      <i class="ScrollTop-icon Icon-collapse" aria-hidden="true"></i>
+      <i class="ScrollTop-icon Icon-collapse" aria-hidden="true" role="img" alt="Scroll to top icon"></i>
       <span class="u-hiddenVisually">{{ scrolltop_text }}</span>
     </a>
   </main>

--- a/docroot/web/themes/custom/agid/templates/navigation/menu--offcanvas--main.html.twig
+++ b/docroot/web/themes/custom/agid/templates/navigation/menu--offcanvas--main.html.twig
@@ -1,0 +1,82 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu in the offcanvas region.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0, '') }}
+
+{% macro menu_links(items, attributes, menu_level, label) %}
+  {% import _self as menus %}
+  {%
+    set root_classes = [
+      'Linklist',
+      'Linklist--padded',
+      'Treeview',
+      'Treeview--default',
+      'js-Treeview',
+      'u-text-r-xs',
+    ]
+  %}
+  {% if items %}
+    {% if menu_level == 0 %}
+    <ul{{ attributes.addClass(root_classes).setAttribute('aria-label', label) }}>
+    {% else %}
+    <ul aria-label={{ label }}>
+    {% endif %}
+    {% for item in items %}
+      <li{{ item.attributes.setAttribute('aria-selected', 'false') }}>
+        {% set link_class = item.url.getOption('attributes').class %}
+        {% set data_megamenu_class = link_class ? " data-megamenu-class=" ~ link_class : '' %}
+        {# If the url isn't empty we print the link with relative attributes #}
+        {% if item.url.toString != "" %}
+          {{ link(item.title, item.url, {'data-megamenu-class': link_class}) }}
+        {#
+          If we have an empty url (route:<none>) we print a custom link with the
+          relative attributes. This is useful when building a megamenu.
+        #}
+        {% else %}
+          {#
+            This code will also support the link_attribute module.
+            Note that the megamenu is builded from the offcanvas treeview menu
+            (the current one).
+            All menu link classes are removed and if we want a class to be added
+            to the megamenu link we must use the data-megamenu-class attribute.
+          #}
+          {% set link_attributes = [] %}
+          {% for attribute, value in item.url.getOption('attributes') %}
+            {% set link_attributes = value ? link_attributes|merge([attribute ~ "=" ~ value]) : link_attributes %}
+          {% endfor %}
+          <button {{ link_attributes|join(' ') }} onclick="return false;" title="{{ item.title }}"{{ data_megamenu_class }}>
+            {{ item.title }}
+          </button>
+        {% endif %}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1, item.title ~ " links" ) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}

--- a/docroot/web/themes/custom/agid/templates/navigation/menu--slim-header-menu.html.twig
+++ b/docroot/web/themes/custom/agid/templates/navigation/menu--slim-header-menu.html.twig
@@ -35,7 +35,7 @@
   <ul>
     {% endif %}
     {% for item in items %}
-      <li{{ item.attributes }}>
+      <li{{ item.attributes.setAttribute('aria-selected', 'false') }}>
         {{ link(item.title, item.url) }}
         {% if item.below %}
           {{ menus.menu_links(item.below, attributes, menu_level + 1) }}

--- a/docroot/web/themes/custom/agid/templates/share_everywhere/share-everywhere.html.twig
+++ b/docroot/web/themes/custom/agid/templates/share_everywhere/share-everywhere.html.twig
@@ -28,8 +28,8 @@
       <h3 class="agid-share__title"> {{ title }} </h3>
     {% endif %}
     <div class="agid-share__trigger">
-      <span class="agid-share__trigger__icon"><img src="/{{ base_path }}/icons/share.svg" aria-label="share icon"></span>
-      <span class="agid-share__trigger__icon agid-share__trigger__icon--hover"><img src="/{{ base_path }}/icons/share-hover.svg" aria-label="share icon"></span>
+      <span class="agid-share__trigger__icon"><img src="/{{ base_path }}/icons/share.svg" aria-label="share icon" alt="Share icon" ></span>
+      <span class="agid-share__trigger__icon agid-share__trigger__icon--hover"><img src="/{{ base_path }}/icons/share-hover.svg" aria-label="share icon" alt="Share icon" ></span>
       <!--<span class="agid-share__trigger__icon Share-revealIcon Icon Icon-share"></span>-->
       <div class="agid-share__trigger__text">
         {{ "Condividi"|t }}

--- a/docroot/web/themes/custom/agid/templates/theme/agid-search-simple-full-text-search.html.twig
+++ b/docroot/web/themes/custom/agid/templates/theme/agid-search-simple-full-text-search.html.twig
@@ -1,20 +1,20 @@
 <form action="{{ view_uri }}" method="get" accept-charset="UTF-8" class="Form"
-      role="search">
+      role="search" aria-labelledby="edit-search_api_fulltext-label-{{ unique_id }}">
   <div
     class="Form-field Form-field--withPlaceholder Grid u-background-white u-text-r-xs u-borderRadius-s">
     <input title="{{ 'Enter the terms to search.'|t }}"
            data-drupal-selector="edit-search_api_fulltext" type="search"
-           id="edit-search_api_fulltext" name="search_api_fulltext" value=""
+           id="edit-search_api_fulltext-{{ unique_id }}" name="search_api_fulltext" value=""
            required="" autocomplete="off"
            class="form-search Form-input Form-input--ultraLean Grid-cell u-sizeFill u-color-black u-text-r-xs u-borderRadius-s"
     >
     <label class="Form-label u-color-grey-50 u-text-r-xxs"
-           for="edit-search_api_fulltext">
+           for="edit-search_api_fulltext-{{ unique_id }}" id="edit-search_api_fulltext-label-{{ unique_id }}">
       {{ "Search in the site"|t }}
     </label>
 
     <button data-twig-context="search_block_form"
-            data-drupal-selector="edit-submit" type="submit" id="edit-submit"
+            data-drupal-selector="edit-submit" type="submit" id="edit-submit-{{ unique_id }}"
             value="{{ 'Search'|t }}"
             class="button js-form-submit form-submit Grid-cell u-sizeFit Icon-search Icon--rotated  u-color-grey-50 u-padding-all-s u-textWeight-700">
       <span class="u-hiddenVisually">{{ 'Start the search'|t }}</span></button>

--- a/docroot/web/themes/custom/italiagov/templates/block/block--language-block--language-interface.html.twig
+++ b/docroot/web/themes/custom/italiagov/templates/block/block--language-block--language-interface.html.twig
@@ -28,13 +28,14 @@
 } %}
 
 
-<div{{ attributes.addClass(container_classes) }}>
+<div{{ attributes.addClass(container_classes).setAttribute('aria-labelledby', 'block-agid-languageswitcher-btn') }}>
   {% block content %}
 
     {# Active language #}
     {% if content.active_language %}
       <button aria-label="{{ 'Seleziona la lingua'|t }}" aria-controls="languages" aria-haspopup="true" class="{{ active_language_classes | join(' ') }}"
-         data-menu-trigger="languages">
+         data-menu-trigger="languages"
+         id="block-agid-languageswitcher-btn">
         <span class="u-hiddenVisually">{{ content.active_language.label_hidden }}:</span>
         <span>{{ active_languages[content.active_language.language_name] | upper }}</span>
         <span class="{{ active_language_span_classes | join(' ') }}"></span>

--- a/docroot/web/themes/custom/italiagov/templates/layout/page.html.twig
+++ b/docroot/web/themes/custom/italiagov/templates/layout/page.html.twig
@@ -125,7 +125,7 @@
     </div>
 
     <div class="u-textCenter u-hidden u-sm-hidden u-md-block u-lg-block">
-      <nav class="Megamenu Megamenu--default js-megamenu" data-rel=".Offcanvas .Treeview"></nav>
+      <nav class="Megamenu Megamenu--default js-megamenu" data-rel=".Offcanvas .Treeview" aria-label="Main menu"></nav>
     </div>
 
   </header>
@@ -252,7 +252,7 @@
 
     {# Scroll to top #}
     <a title="{{ scrolltop_text }}" class="ScrollTop js-scrollTop js-scrollTo" style="display: none; cursor: pointer;">
-      <i class="ScrollTop-icon Icon-collapse" aria-hidden="true"></i>
+      <i class="ScrollTop-icon Icon-collapse" aria-hidden="true" role="img" alt="Scroll to top icon"></i>
       <span class="u-hiddenVisually">{{ scrolltop_text }}</span>
     </a>
   </main>

--- a/docroot/web/themes/custom/italiagov/templates/layout/region--offcanvas.html.twig
+++ b/docroot/web/themes/custom/italiagov/templates/layout/region--offcanvas.html.twig
@@ -24,7 +24,7 @@ set classes = [
 ]
 %}
 {% if content %}
-<section{{ attributes.addClass(classes).setAttribute('id', 'OffcanvasMenu').setAttribute('aria-hidden', 'true') }}>
+<section{{ attributes.addClass(classes).setAttribute('id', 'OffcanvasMenu').setAttribute('aria-hidden', 'true').setAttribute('aria-labelledby', 'block-agid-mainnavigation-menu') }}>
   {{ content }}
 </section>
 {% endif %}


### PR DESCRIPTION
This PR aims to increase Siteimprove accessibility score

All changes are on the filesystem but the following.

## Deploy notes
* W3C rule “Link text used for multiple different destinations” issue is associated to several “PagpPA“ links having the same name, but different paths. They can be solved by adding "/it" into the italian translation of block's body at this link: `/it/block/4`.